### PR TITLE
[DEV] Add pagination to movie/TV category screens

### DIFF
--- a/core/data/src/main/java/com/ant/data/repositories/movies/LoadMovieListRepository.kt
+++ b/core/data/src/main/java/com/ant/data/repositories/movies/LoadMovieListRepository.kt
@@ -1,6 +1,7 @@
 package com.ant.data.repositories.movies
 
 import com.ant.models.entities.MovieData
+import com.ant.models.model.PaginatedResult
 import com.ant.models.request.RequestType
 import com.ant.network.datasource.movies.MovieListDataSource
 import javax.inject.Inject
@@ -10,7 +11,7 @@ import javax.inject.Singleton
 class LoadMovieListRepository @Inject constructor(
     private val movieListDataSource: MovieListDataSource,
 ) {
-    suspend fun performRequest(params: RequestType.MovieRequest): List<MovieData> {
+    suspend fun performRequest(params: RequestType.MovieRequest): PaginatedResult<MovieData> {
         return movieListDataSource.invoke(params)
     }
 }

--- a/core/data/src/main/java/com/ant/data/repositories/tvseries/LoadTvSeriesListRepository.kt
+++ b/core/data/src/main/java/com/ant/data/repositories/tvseries/LoadTvSeriesListRepository.kt
@@ -1,6 +1,7 @@
 package com.ant.data.repositories.tvseries
 
 import com.ant.models.entities.TvShow
+import com.ant.models.model.PaginatedResult
 import com.ant.models.request.RequestType
 import com.ant.network.datasource.tvseries.TvSeriesListDataSource
 import com.ant.network.mappers.tvseries.TvSeriesMapper
@@ -13,7 +14,7 @@ class LoadTvSeriesListRepository @Inject constructor(
     private val tmdbService: Tmdb,
     private val tvSeriesMapper: TvSeriesMapper,
 ) {
-    suspend fun performRequest(params: RequestType.TvShowRequest): List<TvShow> {
+    suspend fun performRequest(params: RequestType.TvShowRequest): PaginatedResult<TvShow> {
         return TvSeriesListDataSource(
             params,
             tmdbService,

--- a/core/domain/src/main/java/com/ant/domain/usecases/movies/MovieListUseCase.kt
+++ b/core/domain/src/main/java/com/ant/domain/usecases/movies/MovieListUseCase.kt
@@ -4,6 +4,7 @@ import com.ant.common.qualifiers.IoDispatcher
 import com.ant.data.repositories.movies.LoadMovieListRepository
 import com.ant.domain.usecases.resultFlow
 import com.ant.models.entities.MovieData
+import com.ant.models.model.PaginatedResult
 import com.ant.models.model.Result
 import com.ant.models.request.RequestType
 import kotlinx.coroutines.CoroutineDispatcher
@@ -14,7 +15,7 @@ class MovieListUseCase @Inject constructor(
     private val repository: LoadMovieListRepository,
     @IoDispatcher private val dispatcher: CoroutineDispatcher,
 ) {
-    operator fun invoke(parameters: RequestType.MovieRequest): Flow<Result<List<MovieData>>> {
+    operator fun invoke(parameters: RequestType.MovieRequest): Flow<Result<PaginatedResult<MovieData>>> {
         return resultFlow(dispatcher) {
             repository.performRequest(parameters)
         }

--- a/core/domain/src/main/java/com/ant/domain/usecases/tvseries/TvShowListUseCase.kt
+++ b/core/domain/src/main/java/com/ant/domain/usecases/tvseries/TvShowListUseCase.kt
@@ -4,6 +4,7 @@ import com.ant.common.qualifiers.IoDispatcher
 import com.ant.data.repositories.tvseries.LoadTvSeriesListRepository
 import com.ant.domain.usecases.resultFlow
 import com.ant.models.entities.TvShow
+import com.ant.models.model.PaginatedResult
 import com.ant.models.model.Result
 import com.ant.models.request.RequestType
 import kotlinx.coroutines.CoroutineDispatcher
@@ -14,7 +15,7 @@ class TvShowListUseCase @Inject constructor(
     private val repository: LoadTvSeriesListRepository,
     @IoDispatcher private val dispatcher: CoroutineDispatcher,
 ) {
-    operator fun invoke(parameters: RequestType.TvShowRequest): Flow<Result<List<TvShow>>> {
+    operator fun invoke(parameters: RequestType.TvShowRequest): Flow<Result<PaginatedResult<TvShow>>> {
         return resultFlow(dispatcher) {
             repository.performRequest(parameters)
         }

--- a/core/models/src/main/java/com/ant/models/model/PaginatedResult.kt
+++ b/core/models/src/main/java/com/ant/models/model/PaginatedResult.kt
@@ -1,0 +1,7 @@
+package com.ant.models.model
+
+data class PaginatedResult<T>(
+    val items: List<T>,
+    val page: Int,
+    val totalPages: Int,
+)

--- a/core/network/src/main/java/com/ant/network/datasource/movies/MovieListDataSource.kt
+++ b/core/network/src/main/java/com/ant/network/datasource/movies/MovieListDataSource.kt
@@ -3,6 +3,7 @@ package com.ant.network.datasource.movies
 import com.ant.common.exceptions.bodyOrThrow
 import com.ant.common.exceptions.withRetry
 import com.ant.models.entities.MovieData
+import com.ant.models.model.PaginatedResult
 import com.ant.models.request.MovieType
 import com.ant.models.request.RequestType
 import com.ant.network.mappers.movies.MoviesListMapper
@@ -21,7 +22,7 @@ class MovieListDataSource @Inject constructor(
 ) {
     suspend operator fun invoke(
         params: RequestType.MovieRequest,
-    ): List<MovieData> {
+    ): PaginatedResult<MovieData> {
         val movieService = tmdb.moviesService()
 
         val movieResultsPageResponse = when (params.movieType) {

--- a/core/network/src/main/java/com/ant/network/datasource/search/SearchMovieDataSource.kt
+++ b/core/network/src/main/java/com/ant/network/datasource/search/SearchMovieDataSource.kt
@@ -33,6 +33,6 @@ class SearchMovieDataSource @Inject constructor(
         val searchResults = searchResultResponse.bodyOrThrow()
         val genreResults = genreResponse.bodyOrThrow()
 
-        return moviesListMapper.map(Pair(searchResults, genreResults))
+        return moviesListMapper.map(Pair(searchResults, genreResults)).items
     }
 }

--- a/core/network/src/main/java/com/ant/network/datasource/search/SearchTvShowDataSource.kt
+++ b/core/network/src/main/java/com/ant/network/datasource/search/SearchTvShowDataSource.kt
@@ -31,6 +31,6 @@ class SearchTvShowDataSource @Inject constructor(
         val searchResults = searchResultResponse.bodyOrThrow()
         val genreResults = genreResponse.bodyOrThrow()
 
-        return tvSeriesMapper.map(Pair(searchResults, genreResults))
+        return tvSeriesMapper.map(Pair(searchResults, genreResults)).items
     }
 }

--- a/core/network/src/main/java/com/ant/network/datasource/tvseries/TvSeriesListDataSource.kt
+++ b/core/network/src/main/java/com/ant/network/datasource/tvseries/TvSeriesListDataSource.kt
@@ -3,6 +3,7 @@ package com.ant.network.datasource.tvseries
 import com.ant.common.exceptions.bodyOrThrow
 import com.ant.common.exceptions.withRetry
 import com.ant.models.entities.TvShow
+import com.ant.models.model.PaginatedResult
 import com.ant.models.request.RequestType
 import com.ant.models.request.TvShowType
 import com.ant.network.mappers.tvseries.TvSeriesMapper
@@ -17,7 +18,7 @@ class TvSeriesListDataSource(
     private val tmdb: Tmdb,
     private val tvSeriesMapper: TvSeriesMapper,
 ) {
-    suspend operator fun invoke(): List<TvShow> {
+    suspend operator fun invoke(): PaginatedResult<TvShow> {
         val tvService = tmdb.tvService()
         val tvShowResultsPageResponse = when (params.tvSeriesType) {
             TvShowType.ONTV_NOW -> onTheAir(tvService, params)
@@ -32,12 +33,9 @@ class TvSeriesListDataSource(
         val genresList = genreResponse.bodyOrThrow()
         val tvShowResultsPage = tvShowResultsPageResponse.bodyOrThrow()
 
-        val tvShowList = tvShowResultsPageResponse.let {
-            tvSeriesMapper.map(
-                Pair(tvShowResultsPage, genresList)
-            )
-        }
-        return tvShowList
+        return tvSeriesMapper.map(
+            Pair(tvShowResultsPage, genresList)
+        )
     }
 
     private suspend fun airingToday(

--- a/core/network/src/main/java/com/ant/network/mappers/movies/MoviesListMapper.kt
+++ b/core/network/src/main/java/com/ant/network/mappers/movies/MoviesListMapper.kt
@@ -1,6 +1,7 @@
 package com.ant.network.mappers.movies
 
 import com.ant.models.entities.MovieData
+import com.ant.models.model.PaginatedResult
 import com.ant.network.mappers.Mapper
 import com.uwetrottmann.tmdb2.entities.Genre
 import com.uwetrottmann.tmdb2.entities.GenreResults
@@ -11,15 +12,20 @@ import javax.inject.Singleton
 @Singleton
 class MoviesListMapper @Inject constructor(
     private val movieDataMapper: MovieDataMapper,
-) : Mapper<Pair<MovieResultsPage, GenreResults>, List<MovieData>> {
-    override suspend fun map(from: Pair<MovieResultsPage, GenreResults>): List<MovieData> {
+) : Mapper<Pair<MovieResultsPage, GenreResults>, PaginatedResult<MovieData>> {
+    override suspend fun map(from: Pair<MovieResultsPage, GenreResults>): PaginatedResult<MovieData> {
         val results = from.first
         val genres = from.second.genres
-        return results.results?.map {
+        val items = results.results?.map {
             val movie = movieDataMapper.map(it)
             val filteredGenres = movie._genres_ids?.filterGenres(genres)
             movie.copy(_genres = emptyList()) //TODO: filteredGenres?.toGenreAsStringList()
         } ?: emptyList()
+        return PaginatedResult(
+            items = items,
+            page = results.page ?: 1,
+            totalPages = results.total_pages ?: 1,
+        )
     }
 }
 

--- a/core/network/src/main/java/com/ant/network/mappers/tvseries/TvSeriesMapper.kt
+++ b/core/network/src/main/java/com/ant/network/mappers/tvseries/TvSeriesMapper.kt
@@ -1,6 +1,7 @@
 package com.ant.network.mappers.tvseries
 
 import com.ant.models.entities.TvShow
+import com.ant.models.model.PaginatedResult
 import com.ant.network.mappers.Mapper
 import com.uwetrottmann.tmdb2.entities.Genre
 import com.uwetrottmann.tmdb2.entities.GenreResults
@@ -11,15 +12,20 @@ import javax.inject.Singleton
 @Singleton
 class TvSeriesMapper @Inject constructor(
     private val tvSeriesDataMapper: TvSeriesDataMapper
-) : Mapper<Pair<TvShowResultsPage, GenreResults>, List<TvShow>> {
-    override suspend fun map(from: Pair<TvShowResultsPage, GenreResults>): List<TvShow> {
+) : Mapper<Pair<TvShowResultsPage, GenreResults>, PaginatedResult<TvShow>> {
+    override suspend fun map(from: Pair<TvShowResultsPage, GenreResults>): PaginatedResult<TvShow> {
         val results = from.first
         val genres = from.second.genres
-        return results.results?.map {
+        val items = results.results?.map {
             val movie = tvSeriesDataMapper.map(it)
             val filteredGenres = movie._genres_ids?.filterGenres(genres)
             movie.copy(_genres = emptyList()) //TODO: filteredGenres?.toGenreAsStringList()
         } ?: emptyList()
+        return PaginatedResult(
+            items = items,
+            page = results.page ?: 1,
+            totalPages = results.total_pages ?: 1,
+        )
     }
 }
 

--- a/features/login/src/main/kotlin/com/ant/feature/login/welcome/WelcomeViewModel.kt
+++ b/features/login/src/main/kotlin/com/ant/feature/login/welcome/WelcomeViewModel.kt
@@ -42,7 +42,7 @@ class WelcomeViewModel @Inject constructor(
                         _uiState.update { it.copy(isLoading = true) }
                     }
                     is Result.Success -> {
-                        val movie = result.data
+                        val movie = result.data.items
                             .filter { !it.backDropPath.isNullOrBlank() }
                             .randomOrNull()
                         _uiState.update {

--- a/features/movies/src/main/kotlin/com/ant/feature/movies/MoviesViewModel.kt
+++ b/features/movies/src/main/kotlin/com/ant/feature/movies/MoviesViewModel.kt
@@ -83,7 +83,7 @@ class MoviesViewModel @Inject constructor(
                             val updatedSections = currentState.movieSections.toMutableMap()
                             updatedSections[category] = MovieSection(
                                 category = category,
-                                movies = result.data,
+                                movies = result.data.items,
                                 isLoading = false
                             )
                             currentState.copy(

--- a/features/movies/src/main/kotlin/com/ant/feature/movies/category/MovieCategoryUiState.kt
+++ b/features/movies/src/main/kotlin/com/ant/feature/movies/category/MovieCategoryUiState.kt
@@ -9,4 +9,10 @@ data class MovieCategoryUiState(
     val isLoading: Boolean = false,
     val error: String? = null,
     val isRefreshing: Boolean = false,
-)
+    val currentPage: Int = 0,
+    val totalPages: Int = 1,
+    val isLoadingMore: Boolean = false,
+) {
+    val canLoadMore: Boolean
+        get() = currentPage < totalPages && !isLoadingMore && !isLoading && error == null
+}

--- a/features/movies/src/main/kotlin/com/ant/feature/movies/category/ui/MovieCategoryRoute.kt
+++ b/features/movies/src/main/kotlin/com/ant/feature/movies/category/ui/MovieCategoryRoute.kt
@@ -21,6 +21,7 @@ fun MovieCategoryRoute(
         onMovieClick = onNavigateToDetails,
         onNavigateBack = onNavigateBack,
         onRefresh = viewModel::refresh,
+        onLoadMore = viewModel::loadNextPage,
         modifier = modifier,
     )
 }

--- a/features/tvshow/src/main/kotlin/com/ant/feature/tvshow/TvShowViewModel.kt
+++ b/features/tvshow/src/main/kotlin/com/ant/feature/tvshow/TvShowViewModel.kt
@@ -82,7 +82,7 @@ class TvShowViewModel @Inject constructor(
                             val updatedSections = currentState.tvShowSections.toMutableMap()
                             updatedSections[category] = TvShowSection(
                                 category = category,
-                                tvShows = result.data,
+                                tvShows = result.data.items,
                                 isLoading = false
                             )
                             currentState.copy(

--- a/features/tvshow/src/main/kotlin/com/ant/feature/tvshow/category/TvShowCategoryUiState.kt
+++ b/features/tvshow/src/main/kotlin/com/ant/feature/tvshow/category/TvShowCategoryUiState.kt
@@ -9,4 +9,10 @@ data class TvShowCategoryUiState(
     val isLoading: Boolean = false,
     val error: String? = null,
     val isRefreshing: Boolean = false,
-)
+    val currentPage: Int = 0,
+    val totalPages: Int = 1,
+    val isLoadingMore: Boolean = false,
+) {
+    val canLoadMore: Boolean
+        get() = currentPage < totalPages && !isLoadingMore && !isLoading && error == null
+}

--- a/features/tvshow/src/main/kotlin/com/ant/feature/tvshow/category/ui/TvShowCategoryRoute.kt
+++ b/features/tvshow/src/main/kotlin/com/ant/feature/tvshow/category/ui/TvShowCategoryRoute.kt
@@ -21,6 +21,7 @@ fun TvShowCategoryRoute(
         onTvShowClick = onNavigateToDetails,
         onNavigateBack = onNavigateBack,
         onRefresh = viewModel::refresh,
+        onLoadMore = viewModel::loadNextPage,
         modifier = modifier,
     )
 }


### PR DESCRIPTION
# MR: Add pagination to movie/TV category screens

**Branch:** `feature/add-pagination-category-screens`
**Target:** `main`

## Summary

Adds infinite scroll pagination to movie and TV show category screens. Introduces a `PaginatedResult<T>` model that threads TMDb page metadata (page number, total pages) through the entire data pipeline — from network mappers up to ViewModels — enabling category screens to load additional pages as the user scrolls.

## Changes

### New model
- **`PaginatedResult<T>`** (`core/models`) — Generic wrapper holding `items: List<T>`, `page: Int`, and `totalPages: Int`.

### Data pipeline updates (core)
| Layer | Files | Change |
|-------|-------|--------|
| **Mappers** | `MoviesListMapper`, `TvSeriesMapper` | Return `PaginatedResult<T>` instead of `List<T>`, extracting `page`/`total_pages` from TMDb response. |
| **DataSources** | `MovieListDataSource`, `TvSeriesListDataSource` | Return type changed to `PaginatedResult<T>`. |
| **Repositories** | `LoadMovieListRepository`, `LoadTvSeriesListRepository` | Return type changed to `PaginatedResult<T>`. |
| **Use Cases** | `MovieListUseCase`, `TvShowListUseCase` | Return `Flow<Result<PaginatedResult<T>>>`. |
| **Search DataSources** | `SearchMovieDataSource`, `SearchTvShowDataSource` | Extract `.items` from `PaginatedResult` (search doesn't paginate yet). |

### Feature: Category screens (movies + TV shows)
- **UiState** (`MovieCategoryUiState`, `TvShowCategoryUiState`):
  - Added `currentPage`, `totalPages`, `isLoadingMore` fields.
  - Added computed `canLoadMore` property (guards against redundant requests).
- **ViewModel** (`MovieCategoryViewModel`, `TvShowCategoryViewModel`):
  - New `loadNextPage()` public function guarded by `canLoadMore`.
  - `loadMovies()`/`loadTvShows()` accepts `page` parameter; appends results with `distinctBy { it.id }` deduplication for page > 1.
  - `refresh()` resets pagination state (page, items) before reloading.
  - Loading state distinguishes initial load vs. refresh vs. load-more.
- **Screen** (`MovieCategoryScreen`, `TvShowCategoryScreen`):
  - `LazyVerticalGrid` with `rememberLazyGridState()` + `derivedStateOf` detects scroll near end (threshold: 6 items).
  - `LaunchedEffect` + `snapshotFlow` triggers `onLoadMore()` callback.
  - Full-width `CircularProgressIndicator` footer shown during `isLoadingMore`.
  - Error state only shows full-screen error when item list is empty (allows keeping existing items on pagination error).
- **Route** (`MovieCategoryRoute`, `TvShowCategoryRoute`):
  - Wires `onLoadMore = viewModel::loadNextPage`.
- **Previews**: Added `LoadingMore` preview variant for both screens.

### Home & Welcome screens
- `MoviesViewModel`, `TvShowViewModel`, `WelcomeViewModel`: Extract `.items` from `PaginatedResult` (home screens only show page 1).

### Documentation
- `ARCHITECTURE.md`: Added Pagination section documenting the data flow and infinite scroll implementation. Updated progress table with completed items.

## Files changed (23 files, +299 / -39)

## How to test
- [ ] Open Movies or TV Shows tab
- [ ] Tap "See All" on any category (Popular, Top Rated, etc.)
- [ ] Scroll down — new pages should load automatically when near the bottom
- [ ] Verify loading spinner appears at the bottom while fetching
- [ ] Pull to refresh — list resets and reloads from page 1
- [ ] Verify home screen carousels still work (showing page 1 only)
- [ ] Verify search results still work (no pagination regression)
- [ ] Verify Welcome screen background image still loads
